### PR TITLE
fix(codemod): npm migrate issue

### DIFF
--- a/packages/codemod/src/actions/migrate-action.ts
+++ b/packages/codemod/src/actions/migrate-action.ts
@@ -155,7 +155,7 @@ export async function migrateAction(projectPaths?: string[], options = {} as Mig
   const remainingFiles = [
     ...nextuiFiles.filter((file) => !affectedFiles.has(file)),
     ...remainingNextuiFiles
-  ].filter((file) => !Object.keys(LOCKS).some((lock) => file.includes(lock))); // should ignore lock files
+  ].filter((file) => !Object.keys(LOCKS).some((lock) => file.includes(lock))); // Should ignore lock files
   const runCheckLeftFiles = remainingFiles.length > 0;
 
   // If user not using individual codemod, we need to ask user to replace left files

--- a/packages/codemod/src/helpers/lint.ts
+++ b/packages/codemod/src/helpers/lint.ts
@@ -20,6 +20,8 @@ export async function lintWithESLint(filePaths: string[]) {
     const result = await eslint.lintFiles(filePaths);
 
     await ESLint.outputFixes(result);
+
+    return result;
   }
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## 📝 Description
<!---
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. List any dependencies that are required for this change.
-->

The problem occurs user choose to replace remaining files which it includes package-lock.json then after npm install it will install the @nextui-org version not the replaced @heroui version

![image](https://github.com/user-attachments/assets/2884ff1d-07d5-4aa2-8388-d5f280c87ef7)

## ✅ Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Improvement (non-breaking change which improves an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
